### PR TITLE
only print hasOwnProperty properties

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -74,6 +74,7 @@ function Formatter (opts) {
     opts = opts || {}
     return function (obj, cell) {
         for (var key in obj) {
+            if (!obj.hasOwnProperty(key)) continue
             var o = opts[key]
             cell(
                 (o && o.name) || key,


### PR DESCRIPTION
Tests still pass.

I made this change in my fork because I am using the `mysql` package and it returns an array of row object.  When I did `Table.printArray(rows)` I got a bunch of noise, as each row has a `.parse` and `._typecast` function.  The output included the source of these functions.

This change only prints own properties, which is typically what I think is desired.  This could, of course, be made an option though.

An additional enhancement might be to by default only print something like `[Function: parse]` (using `util.inspect`) instead of the source code.
