### PR TITLE
example of a currency printer function in readme.md was misleading

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For example, here is how currency printer might be defined
 ``` javascript
 function currency(val, width) {
   var str = val.toFixed(2)
-  return width ? str : Table.padLeft(str, width)
+  return width ? Table.padLeft(str, width) : str
 }
 ```
 


### PR DESCRIPTION
Currency function in `readme.md` wasn't working as expected:
- rendered cell value wasn't properly padded left (it's because in the second phase of rendering, when width value is given, function should return `str` processed by `Table.padLeft`, not `str` on its own).